### PR TITLE
Static buildpack dependecy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "heroku-buildpack-static"]
-  path = heroku-buildpack-static
-  url = https://github.com/heroku/heroku-buildpack-static.git
+	path = heroku-buildpack-static
+	url = https://github.com/heroku/heroku-buildpack-static.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "heroku-buildpack-static"]
+  path = heroku-buildpack-static
+  url = https://github.com/heroku/heroku-buildpack-static.git

--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir> <env-dir>
 set -e
 
@@ -72,5 +72,13 @@ fi
 # Build the site
 printf "\\n-----> Building the site"
 cd "${BUILD_DIR}"
-mkdir -p static | indent
+echo "publishDir = \"public_html\"" >> config.toml
 ./hugo | indent
+
+# Run static buildpack
+printf "\\n-----> Running static buildpack compile"
+BP_DIR="$(cd "$(dirname "${0}")"; cd .. || exit; pwd)"
+cd "${BP_DIR}"
+git submodule init | indent
+git submodule update | indent
+heroku-buildpack-static/bin/compile "${BUILD_DIR}" "${CACHE_DIR}" "${ENV_DIR}"

--- a/bin/compile
+++ b/bin/compile
@@ -79,6 +79,5 @@ echo "publishDir = \"public_html\"" >> config.toml
 printf "\\n-----> Running static buildpack compile"
 BP_DIR="$(cd "$(dirname "${0}")"; cd .. || exit; pwd)"
 cd "${BP_DIR}"
-git submodule init | indent
-git submodule update | indent
+git submodule update --init --recursive | indent
 heroku-buildpack-static/bin/compile "${BUILD_DIR}" "${CACHE_DIR}" "${ENV_DIR}"

--- a/bin/detect
+++ b/bin/detect
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 CONFIG_FILE="$(echo config.*)"
 

--- a/bin/release
+++ b/bin/release
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
+rm -f ./hugo
 cd "$(dirname "${0}")" || exit
 cd .. || exit
 git submodule update --init --recursive

--- a/bin/release
+++ b/bin/release
@@ -3,6 +3,5 @@
 
 cd "$(dirname "${0}")" || exit
 cd .. || exit
-git submodule init
-git submodule update
+git submodule update --init --recursive
 heroku-buildpack-static/bin/release "${1}"

--- a/bin/release
+++ b/bin/release
@@ -1,7 +1,8 @@
-#!/bin/sh
+#!/usr/bin/env bash
+# bin/release <build-dir>
 
-cat << EOF
----
-default_process_types:
-  web: "cd public && python -m SimpleHTTPServer \$PORT"
-EOF
+cd "$(dirname "${0}")" || exit
+cd .. || exit
+git submodule init
+git submodule update
+heroku-buildpack-static/bin/release "${1}"


### PR DESCRIPTION
Adding support for static buildpack instead of using Python SimpleHTTPServer

Thanks to @jamesward and he's PR: https://github.com/roperzh/heroku-buildpack-hugo/pull/27